### PR TITLE
Pass http_client_opts from RateLimiter to http client

### DIFF
--- a/lib/shopify/client/rate_limit.ex
+++ b/lib/shopify/client/rate_limit.ex
@@ -2,7 +2,7 @@ defmodule Shopify.Client.RateLimit do
   def request(request, client_opts) do
     server = Keyword.get(client_opts, :name, Shopify.RateLimiter)
 
-    opts = Keyword.take(client_opts, [:http_client])
+    opts = Keyword.take(client_opts, [:http_client, :http_client_opts])
 
     Shopify.RateLimiter.make_request(server, request, opts)
   end


### PR DESCRIPTION
This PR fixes bug when `http_client_opts` is not passed through RateLimiter config to real http client